### PR TITLE
ffho-autoupdater-wifi-fallback: more aggressive

### DIFF
--- a/ffho-autoupdater-wifi-fallback/luasrc/lib/gluon/upgrade/510-autoupdater-wifi-fallback
+++ b/ffho-autoupdater-wifi-fallback/luasrc/lib/gluon/upgrade/510-autoupdater-wifi-fallback
@@ -38,8 +38,11 @@ local file = io.open('/usr/lib/micron.d/autoupdater', 'r')
 local content = file:read "*a"
 local minute = tonumber(content:match('^([0-9][0-9]?)%s'))
 file:close()
-minute = (minute + 10) % 60
+minute = (minute + 10) % 15
 
 local f = io.open('/usr/lib/micron.d/autoupdater-wifi-fallback', 'w')
-f:write(string.format('%i * * * * /usr/sbin/autoupdater-wifi-fallback\n', minute))
+for _ = 1, 4 do -- we want to run it every 15 minutes
+  f:write(string.format('%i * * * * /usr/sbin/autoupdater-wifi-fallback\n', minute))
+  minute = minute + 15
+end
 f:close()

--- a/ffho-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
+++ b/ffho-autoupdater-wifi-fallback/luasrc/usr/sbin/autoupdater-wifi-fallback
@@ -114,7 +114,7 @@ if not uci:get('autoupdater', branch_name) then
 end
 
 if (force or preflight_check()) and not connectivity_check() then
-  local offset = 2 * 3600
+  local offset = 1200 -- 20 minutes
   local unreachable_since = os.time()
   if not uci:get('autoupdater-wifi-fallback', 'settings', 'unreachable_since') then
     uci:set(configname, 'settings', 'unreachable_since', unreachable_since)


### PR DESCRIPTION
Use a 15 minute interval for running the autoupdater-wifi-fallback. Have an offset of at least 20 minutes before executing the actual fallback. This means effectively that after roughly ~30-45 minutes the wifi-fallback is triggered.